### PR TITLE
Fix pts indexing

### DIFF
--- a/av/buffered_decoder.pxd
+++ b/av/buffered_decoder.pxd
@@ -34,10 +34,8 @@ cdef class BufferedDecoder(object):
         CircularBuffer standby_buffer
         CircularBuffer backlog_buffer
         int dec_batch
-        int pts_rate
         long long external_seek
         bint eos
-        object next_frame
         object buffering_sem
         object buffering_lock
         object av_lock

--- a/av/buffered_decoder.pxd
+++ b/av/buffered_decoder.pxd
@@ -28,7 +28,6 @@ cdef class CircularBuffer:
 
 
 cdef class BufferedDecoder(object):
-    cdef long long pts_to_idx(self, long long pts)
     cpdef buffering_thread(self)
     cdef:
         CircularBuffer active_buffer

--- a/av/buffered_decoder.pyx
+++ b/av/buffered_decoder.pyx
@@ -28,6 +28,10 @@ cdef class CircularBuffer:
         self.last_pts = -1
 
     def __dealloc__(self):
+        for i in range(self.buffer_size):
+            frame = self.at(i)
+            if frame:
+                lib.av_frame_free(&frame)
         free(self.buffer)
 
     cdef:

--- a/av/buffered_decoder.pyx
+++ b/av/buffered_decoder.pyx
@@ -116,11 +116,6 @@ cdef class BufferedDecoder(object):
         self.dec_batch = dec_batch
         self.external_seek = -1
         self.buffered_stream.seek(0)
-        self.next_frame = self.decode(container, stream)
-        f1, f2 = next(self.next_frame), next(self.next_frame)
-        self.pts_rate = f2.pts
-        self.buffered_stream.seek(0)
-        #self.next_frame = self.decode(container, stream)
         self.buffering_sem = Semaphore()
         self.buffering_lock = Lock()
         self.av_lock = Lock()

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ is_py3 = sys.version_info[0] >= 3
 
 
 # We will embed this metadata into the package so it can be recalled for debugging.
-version = '0.4.2.dev0'
+version = '0.4.3.dev0'
 try:
     git_commit, _ = Popen(['git', 'describe', '--tags'], stdout=PIPE, stderr=PIPE).communicate()
 except OSError:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ is_py3 = sys.version_info[0] >= 3
 
 
 # We will embed this metadata into the package so it can be recalled for debugging.
-version = '0.4.3.dev0'
+version = '0.4.3'
 try:
     git_commit, _ = Popen(['git', 'describe', '--tags'], stdout=PIPE, stderr=PIPE).communicate()
 except OSError:


### PR DESCRIPTION
Newer recordings do not rely on a fixed pts-rate, so we have to search for the correct index in the buffer instead of calculating it. Since it's sorted we can use binary search though!

Fixed a memory leak as well and cleaned up parts of the code a bit.