### PR TITLE
Fix deprecated numpy call

### DIFF
--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -136,4 +136,4 @@ cdef class AudioFrame(Frame):
             raise AssertionError("Don't know how to convert data type.", self.format.name)
 
         # convert and return data
-        return np.vstack(map(lambda x: np.frombuffer(x, dtype), self.planes))
+        return np.vstack(tuple(map(lambda x: np.frombuffer(x, dtype), self.planes)))

--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -136,4 +136,4 @@ cdef class AudioFrame(Frame):
             raise AssertionError("Don't know how to convert data type.", self.format.name)
 
         # convert and return data
-        return np.vstack(tuple(map(lambda x: np.frombuffer(x, dtype), self.planes)))
+        return np.vstack(tuple(np.frombuffer(x, dtype) for x in self.planes))

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ is_py3 = sys.version_info[0] >= 3
 
 
 # We will embed this metadata into the package so it can be recalled for debugging.
-version = "0.4.3"
+version = "0.4.4"
 try:
     git_commit, _ = Popen(
         ["git", "describe", "--tags"], stdout=PIPE, stderr=PIPE


### PR DESCRIPTION
> FutureWarning: arrays to stack must be passed as a "sequence" type
such as list or tuple. Support for non-sequence iterables such as
generators is deprecated as of NumPy 1.16 and
will raise an error in the future.